### PR TITLE
Added user objects to track positions and cash in memory

### DIFF
--- a/config/trading_engine.json
+++ b/config/trading_engine.json
@@ -39,6 +39,9 @@
         "console_output": true,
         "rotate_logs": true
     },
+    "portfolio": {
+        "starting_cash": 100000.0
+    },
     "matching_engine": {
         "enable_callbacks": true,
         "price_precision": 2,

--- a/include/trading/core/user.hpp
+++ b/include/trading/core/user.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <map>
+#include <optional>
+#include <string>
+
+#include "order.hpp"
+
+namespace trading {
+namespace core {
+
+// Represents a user's position for a single symbol
+struct Position {
+    std::string symbol;
+    double quantity{0.0};
+    double average_price{0.0};
+};
+
+// In-memory representation of a user's portfolio (cash + positions)
+class User {
+  public:
+    explicit User(std::string user_id, double starting_cash);
+    ~User() = default;
+
+    // Identity
+    [[nodiscard]] const std::string& getUserId() const noexcept {
+        return user_id_;
+    }
+
+    // Balances
+    [[nodiscard]] double getCashBalance() const noexcept {
+        return cash_balance_;
+    }
+    [[nodiscard]] double getRealizedPnl() const noexcept {
+        return realized_pnl_;
+    }
+
+    // Cash management
+    bool depositCash(double amount) noexcept;
+    bool withdrawCash(double amount) noexcept;  // returns false if insufficient funds or invalid
+
+    // Position queries
+    [[nodiscard]] std::optional<Position> getPosition(const std::string& symbol) const;
+    [[nodiscard]] const std::map<std::string, Position>& getAllPositions() const noexcept {
+        return symbol_to_position_;
+    }
+
+    // Apply an execution fill from this user's perspective.
+    // - side: BUY means user bought (reduces cash, increases position)
+    //         SELL means user sold (increases cash, reduces position)
+    // - fee: optional per-fill fee to apply to cash (positive number)
+    // Returns false if operation invalid (e.g., insufficient cash or position quantity)
+    bool applyExecution(OrderSide side, const std::string& symbol, double executed_quantity,
+                        double executed_price, double fee = 0.0);
+
+  private:
+    std::string user_id_;
+    double cash_balance_;
+    double realized_pnl_;
+    std::map<std::string, Position> symbol_to_position_;
+};
+
+}  // namespace core
+}  // namespace trading

--- a/src/core/user.cpp
+++ b/src/core/user.cpp
@@ -1,0 +1,107 @@
+#include "trading/core/user.hpp"
+
+#include <algorithm>
+
+namespace trading {
+namespace core {
+
+User::User(std::string user_id, double starting_cash)
+    : user_id_(std::move(user_id)), cash_balance_(starting_cash), realized_pnl_(0.0) {
+}
+
+bool User::depositCash(double amount) noexcept {
+    if (amount <= 0.0) {
+        return false;
+    }
+    cash_balance_ += amount;
+    return true;
+}
+
+bool User::withdrawCash(double amount) noexcept {
+    if (amount <= 0.0 || amount > cash_balance_) {
+        return false;
+    }
+    cash_balance_ -= amount;
+    return true;
+}
+
+std::optional<Position> User::getPosition(const std::string& symbol) const {
+    auto it = symbol_to_position_.find(symbol);
+    if (it == symbol_to_position_.end()) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+bool User::applyExecution(OrderSide side, const std::string& symbol, double executed_quantity,
+                          double executed_price, double fee) {
+    if (executed_quantity <= 0.0 || executed_price < 0.0 || fee < 0.0) {
+        return false;
+    }
+
+    double gross_amount = executed_quantity * executed_price;  // trade notional
+
+    if (side == OrderSide::BUY) {
+        double total_cost = gross_amount + fee;
+        if (total_cost > cash_balance_) {
+            return false;  // insufficient cash
+        }
+
+        // Insert or get existing position now that validation passed
+        auto it = symbol_to_position_.find(symbol);
+        Position* position_ptr;
+        if (it == symbol_to_position_.end()) {
+            auto& inserted = symbol_to_position_[symbol];
+            inserted.symbol = symbol;
+            position_ptr = &inserted;
+        } else {
+            position_ptr = &it->second;
+        }
+        auto& pos = *position_ptr;
+
+        // Update weighted average price
+        double new_quantity = pos.quantity + executed_quantity;
+        if (new_quantity <= 0.0) {
+            // Should not happen for BUY
+            return false;
+        }
+        double previous_cost_basis = pos.average_price * pos.quantity;
+        double new_cost_basis = previous_cost_basis + gross_amount;
+        pos.quantity = new_quantity;
+        pos.average_price = new_cost_basis / new_quantity;
+
+        // Deduct cash
+        cash_balance_ -= total_cost;
+        return true;
+    }
+
+    // SELL path
+    auto it = symbol_to_position_.find(symbol);
+    if (it == symbol_to_position_.end()) {
+        return false;  // cannot sell a non-existent position
+    }
+    auto& pos = it->second;
+    if (executed_quantity > pos.quantity + 1e-12) {
+        return false;  // cannot sell more than owned (no shorting for now)
+    }
+
+    // Realize PnL on sold quantity
+    double cost_basis_of_sold = pos.average_price * executed_quantity;
+    double proceeds = gross_amount - fee;
+    double pnl = proceeds - cost_basis_of_sold;
+    realized_pnl_ += pnl;
+
+    // Update position quantity; average price unchanged for remaining shares
+    pos.quantity -= executed_quantity;
+    if (pos.quantity <= 1e-12) {
+        pos.quantity = 0.0;
+        pos.average_price = 0.0;  // reset when flat
+    }
+
+    // Add cash from sale
+    cash_balance_ += proceeds;
+    return true;
+}
+
+}  // namespace core
+}  // namespace trading

--- a/tests/unit/test_user.cpp
+++ b/tests/unit/test_user.cpp
@@ -1,0 +1,122 @@
+#include "trading/core/order.hpp"
+#include "trading/core/user.hpp"
+#include <gtest/gtest.h>
+
+using namespace trading::core;
+
+class UserTest : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        starting_cash = 10000.0;
+        user = std::make_unique<User>("user-001", starting_cash);
+    }
+
+    double starting_cash;
+    std::unique_ptr<User> user;
+};
+
+TEST_F(UserTest, InitialState) {
+    EXPECT_EQ(user->getUserId(), "user-001");
+    EXPECT_NEAR(user->getCashBalance(), starting_cash, 1e-9);
+    EXPECT_NEAR(user->getRealizedPnl(), 0.0, 1e-12);
+    EXPECT_TRUE(user->getAllPositions().empty());
+}
+
+TEST_F(UserTest, DepositAndWithdrawCash) {
+    ASSERT_TRUE(user->depositCash(500.0));
+    EXPECT_NEAR(user->getCashBalance(), starting_cash + 500.0, 1e-9);
+
+    // Invalid deposit
+    EXPECT_FALSE(user->depositCash(0.0));
+    EXPECT_FALSE(user->depositCash(-10.0));
+    EXPECT_NEAR(user->getCashBalance(), starting_cash + 500.0, 1e-9);
+
+    // Valid withdrawal
+    ASSERT_TRUE(user->withdrawCash(300.0));
+    EXPECT_NEAR(user->getCashBalance(), starting_cash + 200.0, 1e-9);
+
+    // Invalid withdrawal
+    EXPECT_FALSE(user->withdrawCash(0.0));
+    EXPECT_FALSE(user->withdrawCash(-5.0));
+    EXPECT_FALSE(user->withdrawCash(starting_cash + 201.0));
+    EXPECT_NEAR(user->getCashBalance(), starting_cash + 200.0, 1e-9);
+}
+
+TEST_F(UserTest, ApplyExecutionBuyCreatesAndUpdatesPosition) {
+    // Buy 10 @ 100, fee 1.0
+    ASSERT_TRUE(user->applyExecution(OrderSide::BUY, "AAPL", 10.0, 100.0, 1.0));
+    EXPECT_NEAR(user->getCashBalance(), starting_cash - 1001.0, 1e-9);
+    auto pos_opt = user->getPosition("AAPL");
+    ASSERT_TRUE(pos_opt.has_value());
+    EXPECT_NEAR(pos_opt->quantity, 10.0, 1e-9);
+    EXPECT_NEAR(pos_opt->average_price, 100.0, 1e-12);
+    EXPECT_NEAR(user->getRealizedPnl(), 0.0, 1e-12);
+
+    // Buy additional 20 @ 110, fee 2.0
+    ASSERT_TRUE(user->applyExecution(OrderSide::BUY, "AAPL", 20.0, 110.0, 2.0));
+    EXPECT_NEAR(user->getCashBalance(), starting_cash - 1001.0 - 2202.0, 1e-9);
+    pos_opt = user->getPosition("AAPL");
+    ASSERT_TRUE(pos_opt.has_value());
+    EXPECT_NEAR(pos_opt->quantity, 30.0, 1e-9);
+    EXPECT_NEAR(pos_opt->average_price, (1000.0 + 2200.0) / 30.0, 1e-9);
+}
+
+TEST_F(UserTest, ApplyExecutionSellRealizesPnLAndReducesPosition) {
+    // Build position: 10 @ 100 (fee 1), then 20 @ 110 (fee 2)
+    ASSERT_TRUE(user->applyExecution(OrderSide::BUY, "AAPL", 10.0, 100.0, 1.0));
+    ASSERT_TRUE(user->applyExecution(OrderSide::BUY, "AAPL", 20.0, 110.0, 2.0));
+    const double avg_price = (1000.0 + 2200.0) / 30.0;  // 106.666...
+
+    // Sell 5 @ 120, fee 1
+    ASSERT_TRUE(user->applyExecution(OrderSide::SELL, "AAPL", 5.0, 120.0, 1.0));
+    auto pos_opt = user->getPosition("AAPL");
+    ASSERT_TRUE(pos_opt.has_value());
+    EXPECT_NEAR(pos_opt->quantity, 25.0, 1e-9);
+    EXPECT_NEAR(pos_opt->average_price, avg_price, 1e-9);  // unchanged on partial sell
+
+    // Realized PnL: (5*120 - 1) - 5*avg
+    double expected_pnl1 = (600.0 - 1.0) - 5.0 * avg_price;  // 599 - cost basis
+    EXPECT_NEAR(user->getRealizedPnl(), expected_pnl1, 1e-9);
+
+    // Sell remaining 25 @ 100, no fee
+    ASSERT_TRUE(user->applyExecution(OrderSide::SELL, "AAPL", 25.0, 100.0, 0.0));
+    pos_opt = user->getPosition("AAPL");
+    ASSERT_TRUE(pos_opt.has_value());
+    EXPECT_NEAR(pos_opt->quantity, 0.0, 1e-12);
+    EXPECT_NEAR(pos_opt->average_price, 0.0, 1e-12);  // reset when flat
+
+    // Total PnL should be -101.0 exactly with these numbers
+    EXPECT_NEAR(user->getRealizedPnl(), -101.0, 1e-9);
+}
+
+TEST_F(UserTest, ApplyExecutionFailsOnInsufficientCash) {
+    User low_cash_user("user-002", 100.0);
+    // Buying 1 @ 100 with fee 1 exceeds 100
+    EXPECT_FALSE(low_cash_user.applyExecution(OrderSide::BUY, "AAPL", 1.0, 100.0, 1.0));
+
+    // Trade should have no effect on user's cash balance because it failed
+    EXPECT_NEAR(low_cash_user.getCashBalance(), 100.0, 1e-12);
+
+    // User should have no positions
+    std::cout << "low_cash_user.getAllPositions().size(): "
+              << low_cash_user.getAllPositions().size() << std::endl;
+    EXPECT_TRUE(low_cash_user.getAllPositions().empty());
+}
+
+TEST_F(UserTest, ApplyExecutionFailsOnOversell) {
+    ASSERT_TRUE(user->applyExecution(OrderSide::BUY, "AAPL", 5.0, 10.0, 0.0));
+    // Attempt to sell more than owned
+    EXPECT_FALSE(user->applyExecution(OrderSide::SELL, "AAPL", 10.0, 10.0, 0.0));
+    auto pos_opt = user->getPosition("AAPL");
+    ASSERT_TRUE(pos_opt.has_value());
+    EXPECT_NEAR(pos_opt->quantity, 5.0, 1e-12);
+}
+
+TEST_F(UserTest, ApplyExecutionRejectsInvalidInputs) {
+    // Non-positive quantity
+    EXPECT_FALSE(user->applyExecution(OrderSide::BUY, "AAPL", 0.0, 100.0, 0.0));
+    EXPECT_FALSE(user->applyExecution(OrderSide::BUY, "AAPL", -1.0, 100.0, 0.0));
+    // Negative price or fee
+    EXPECT_FALSE(user->applyExecution(OrderSide::BUY, "AAPL", 1.0, -1.0, 0.0));
+    EXPECT_FALSE(user->applyExecution(OrderSide::BUY, "AAPL", 1.0, 100.0, -0.5));
+}


### PR DESCRIPTION
This pull request introduces a new in-memory user portfolio management system for the trading engine, including the ability to track cash balances, positions, and realized profit and loss (PnL) for each user. It also adds configuration support for starting cash and a comprehensive unit test suite to validate the new functionality.

**Core portfolio management features:**

* Added a new `User` class in `trading/core/user.hpp` to represent a user's cash balance, positions per symbol, and realized PnL, with methods for depositing/withdrawing cash and applying trade executions.
* Implemented the `User` class logic in `src/core/user.cpp`, including position updates, cash management, and PnL calculation for buy/sell executions.

**Configuration and testing:**

* Updated `config/trading_engine.json` to support configurable starting cash for user portfolios.
* Added a comprehensive unit test suite in `tests/unit/test_user.cpp` to verify `User` behavior, including cash management, position updates, PnL calculation, and edge case handling.