### PR TITLE
Built Order Matching Engine

### DIFF
--- a/config/trading_engine.json
+++ b/config/trading_engine.json
@@ -39,6 +39,9 @@
         "console_output": true,
         "rotate_logs": true
     },
+    "portfolio": {
+        "starting_cash": 100000.0
+    },
     "matching_engine": {
         "enable_callbacks": true,
         "price_precision": 2,

--- a/include/trading/core/matching_engine.hpp
+++ b/include/trading/core/matching_engine.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include "order.hpp"
 #include "orderbook.hpp"
+#include "user.hpp"
 
 namespace trading {
 namespace core {
@@ -15,6 +16,8 @@ struct Trade {
     std::string trade_id;
     std::string buy_order_id;
     std::string sell_order_id;
+    std::string buy_user_id;   // User ID of the buyer
+    std::string sell_user_id;  // User ID of the seller
     std::string symbol;
     double quantity;
     double price;
@@ -35,6 +38,12 @@ class MatchingEngine {
     // Matching logic
     std::vector<Trade> matchOrder(std::shared_ptr<Order> order, OrderBook& orderbook);
 
+    // User management
+    void addUser(std::shared_ptr<User> user);
+    std::shared_ptr<User> getUser(const std::string& user_id);
+    std::shared_ptr<User> getOrCreateUser(const std::string& user_id,
+                                          double starting_cash = 10000.0);
+
     // Event handling
     void setTradeCallback(TradeCallback callback);
 
@@ -48,11 +57,15 @@ class MatchingEngine {
     double total_volume_;
     uint64_t next_trade_id_;
     std::map<std::string, std::shared_ptr<OrderBook>> orderbooks_;
+    std::map<std::string, std::shared_ptr<User>> users_;  // User registry
 
     std::vector<Trade> matchMarketOrder(std::shared_ptr<Order> order, OrderBook& orderbook);
     std::vector<Trade> matchLimitOrder(std::shared_ptr<Order> order, OrderBook& orderbook);
     Trade createTrade(std::shared_ptr<Order> buy_order, std::shared_ptr<Order> sell_order,
                       double quantity, double price);
+
+    // Portfolio update helper
+    bool updateUserPortfolios(const Trade& trade, double fee = 0.0);
 };
 
 }  // namespace core

--- a/include/trading/core/user.hpp
+++ b/include/trading/core/user.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <map>
+#include <optional>
+#include <string>
+
+#include "order.hpp"
+
+namespace trading {
+namespace core {
+
+// Represents a user's position for a single symbol
+struct Position {
+    std::string symbol;
+    double quantity{0.0};
+    double average_price{0.0};
+};
+
+// In-memory representation of a user's portfolio (cash + positions)
+class User {
+  public:
+    explicit User(std::string user_id, double starting_cash);
+    ~User() = default;
+
+    // Identity
+    [[nodiscard]] const std::string& getUserId() const noexcept {
+        return user_id_;
+    }
+
+    // Balances
+    [[nodiscard]] double getCashBalance() const noexcept {
+        return cash_balance_;
+    }
+    [[nodiscard]] double getRealizedPnl() const noexcept {
+        return realized_pnl_;
+    }
+
+    // Cash management
+    bool depositCash(double amount) noexcept;
+    bool withdrawCash(double amount) noexcept;  // returns false if insufficient funds or invalid
+
+    // Position queries
+    [[nodiscard]] std::optional<Position> getPosition(const std::string& symbol) const;
+    [[nodiscard]] const std::map<std::string, Position>& getAllPositions() const noexcept {
+        return symbol_to_position_;
+    }
+
+    // Apply an execution fill from this user's perspective.
+    // - side: BUY means user bought (reduces cash, increases position)
+    //         SELL means user sold (increases cash, reduces position)
+    // - fee: optional per-fill fee to apply to cash (positive number)
+    // Returns false if operation invalid (e.g., insufficient cash or position quantity)
+    bool applyExecution(OrderSide side, const std::string& symbol, double executed_quantity,
+                        double executed_price, double fee = 0.0);
+
+  private:
+    std::string user_id_;
+    double cash_balance_;
+    double realized_pnl_;
+    std::map<std::string, Position> symbol_to_position_;
+};
+
+}  // namespace core
+}  // namespace trading

--- a/src/core/matching_engine.cpp
+++ b/src/core/matching_engine.cpp
@@ -61,7 +61,12 @@ std::vector<Trade> MatchingEngine::matchMarketOrder(std::shared_ptr<Order> order
             (order->getSide() == OrderSide::SELL &&
              opposite_order->getPrice() >= best_price_order)) {
             double trade_quantity = std::min(remaining_quantity, opposite_order->getQuantity());
-            Trade trade = createTrade(order, opposite_order, trade_quantity, best_price_order);
+
+            // Determine buy/sell orders for the trade
+            auto buy_order = (order->getSide() == OrderSide::BUY) ? order : opposite_order;
+            auto sell_order = (order->getSide() == OrderSide::SELL) ? order : opposite_order;
+
+            Trade trade = createTrade(buy_order, sell_order, trade_quantity, best_price_order);
             trades.push_back(trade);
             remaining_quantity -= trade_quantity;
 
@@ -75,10 +80,18 @@ std::vector<Trade> MatchingEngine::matchMarketOrder(std::shared_ptr<Order> order
         }
     }
 
-    // Update total trades and volume
+    // Update total trades and volume and user portfolios
     total_trades_ += trades.size();
     for (const auto& trade : trades) {
         total_volume_ += trade.quantity * trade.price;
+
+        // Update user portfolios using the trade information
+        updateUserPortfolios(trade);
+
+        // Notify via trade callback if set
+        if (trade_callback_) {
+            trade_callback_(trade);
+        }
     }
 
     // Return trades
@@ -106,7 +119,12 @@ std::vector<Trade> MatchingEngine::matchLimitOrder(std::shared_ptr<Order> order,
             (order->getSide() == OrderSide::SELL &&
              opposite_order->getPrice() >= order->getPrice())) {
             double trade_quantity = std::min(remaining_quantity, opposite_order->getQuantity());
-            Trade trade = createTrade(order, opposite_order, trade_quantity, order->getPrice());
+
+            // Determine buy/sell orders for the trade
+            auto buy_order = (order->getSide() == OrderSide::BUY) ? order : opposite_order;
+            auto sell_order = (order->getSide() == OrderSide::SELL) ? order : opposite_order;
+
+            Trade trade = createTrade(buy_order, sell_order, trade_quantity, order->getPrice());
             trades.push_back(trade);
             remaining_quantity -= trade_quantity;
 
@@ -124,6 +142,14 @@ std::vector<Trade> MatchingEngine::matchLimitOrder(std::shared_ptr<Order> order,
     total_trades_ += trades.size();
     for (const auto& trade : trades) {
         total_volume_ += trade.quantity * trade.price;
+
+        // Update user portfolios using the trade information
+        updateUserPortfolios(trade);
+
+        // Notify via trade callback if set
+        if (trade_callback_) {
+            trade_callback_(trade);
+        }
     }
 
     // Return trades
@@ -137,6 +163,8 @@ Trade MatchingEngine::createTrade(std::shared_ptr<Order> buy_order,
     trade.trade_id = std::to_string(next_trade_id_++);
     trade.buy_order_id = buy_order->getId();
     trade.sell_order_id = sell_order->getId();
+    trade.buy_user_id = buy_order->getUserId();
+    trade.sell_user_id = sell_order->getUserId();
     trade.symbol = buy_order->getSymbol();
     trade.quantity = quantity;
     trade.price = price;
@@ -152,6 +180,44 @@ std::shared_ptr<OrderBook> MatchingEngine::getOrderBook(const std::string& symbo
         return it->second;
     }
     return nullptr;
+}
+
+void MatchingEngine::addUser(std::shared_ptr<User> user) {
+    users_[user->getUserId()] = user;
+}
+
+std::shared_ptr<User> MatchingEngine::getUser(const std::string& user_id) {
+    auto it = users_.find(user_id);
+    if (it != users_.end()) {
+        return it->second;
+    }
+    return nullptr;
+}
+
+std::shared_ptr<User> MatchingEngine::getOrCreateUser(const std::string& user_id,
+                                                      double starting_cash) {
+    auto user = getUser(user_id);
+    if (!user) {
+        user = std::make_shared<User>(user_id, starting_cash);
+        addUser(user);
+    }
+    return user;
+}
+
+bool MatchingEngine::updateUserPortfolios(const Trade& trade, double fee) {
+    // Get or create users (with default starting cash if new)
+    auto buyer = getOrCreateUser(trade.buy_user_id);
+    auto seller = getOrCreateUser(trade.sell_user_id);
+
+    // Apply execution to buyer (BUY side)
+    bool buyer_success =
+        buyer->applyExecution(OrderSide::BUY, trade.symbol, trade.quantity, trade.price, fee);
+
+    // Apply execution to seller (SELL side)
+    bool seller_success =
+        seller->applyExecution(OrderSide::SELL, trade.symbol, trade.quantity, trade.price, fee);
+
+    return buyer_success && seller_success;
 }
 
 }  // namespace core

--- a/src/core/user.cpp
+++ b/src/core/user.cpp
@@ -1,0 +1,107 @@
+#include "trading/core/user.hpp"
+
+#include <algorithm>
+
+namespace trading {
+namespace core {
+
+User::User(std::string user_id, double starting_cash)
+    : user_id_(std::move(user_id)), cash_balance_(starting_cash), realized_pnl_(0.0) {
+}
+
+bool User::depositCash(double amount) noexcept {
+    if (amount <= 0.0) {
+        return false;
+    }
+    cash_balance_ += amount;
+    return true;
+}
+
+bool User::withdrawCash(double amount) noexcept {
+    if (amount <= 0.0 || amount > cash_balance_) {
+        return false;
+    }
+    cash_balance_ -= amount;
+    return true;
+}
+
+std::optional<Position> User::getPosition(const std::string& symbol) const {
+    auto it = symbol_to_position_.find(symbol);
+    if (it == symbol_to_position_.end()) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+bool User::applyExecution(OrderSide side, const std::string& symbol, double executed_quantity,
+                          double executed_price, double fee) {
+    if (executed_quantity <= 0.0 || executed_price < 0.0 || fee < 0.0) {
+        return false;
+    }
+
+    double gross_amount = executed_quantity * executed_price;  // trade notional
+
+    if (side == OrderSide::BUY) {
+        double total_cost = gross_amount + fee;
+        if (total_cost > cash_balance_) {
+            return false;  // insufficient cash
+        }
+
+        // Insert or get existing position now that validation passed
+        auto it = symbol_to_position_.find(symbol);
+        Position* position_ptr;
+        if (it == symbol_to_position_.end()) {
+            auto& inserted = symbol_to_position_[symbol];
+            inserted.symbol = symbol;
+            position_ptr = &inserted;
+        } else {
+            position_ptr = &it->second;
+        }
+        auto& pos = *position_ptr;
+
+        // Update weighted average price
+        double new_quantity = pos.quantity + executed_quantity;
+        if (new_quantity <= 0.0) {
+            // Should not happen for BUY
+            return false;
+        }
+        double previous_cost_basis = pos.average_price * pos.quantity;
+        double new_cost_basis = previous_cost_basis + gross_amount;
+        pos.quantity = new_quantity;
+        pos.average_price = new_cost_basis / new_quantity;
+
+        // Deduct cash
+        cash_balance_ -= total_cost;
+        return true;
+    }
+
+    // SELL path
+    auto it = symbol_to_position_.find(symbol);
+    if (it == symbol_to_position_.end()) {
+        return false;  // cannot sell a non-existent position
+    }
+    auto& pos = it->second;
+    if (executed_quantity > pos.quantity + 1e-12) {
+        return false;  // cannot sell more than owned (no shorting for now)
+    }
+
+    // Realize PnL on sold quantity
+    double cost_basis_of_sold = pos.average_price * executed_quantity;
+    double proceeds = gross_amount - fee;
+    double pnl = proceeds - cost_basis_of_sold;
+    realized_pnl_ += pnl;
+
+    // Update position quantity; average price unchanged for remaining shares
+    pos.quantity -= executed_quantity;
+    if (pos.quantity <= 1e-12) {
+        pos.quantity = 0.0;
+        pos.average_price = 0.0;  // reset when flat
+    }
+
+    // Add cash from sale
+    cash_balance_ += proceeds;
+    return true;
+}
+
+}  // namespace core
+}  // namespace trading

--- a/tests/unit/test_matching_engine.cpp
+++ b/tests/unit/test_matching_engine.cpp
@@ -1,0 +1,302 @@
+#include "trading/core/matching_engine.hpp"
+#include "trading/core/order.hpp"
+#include "trading/core/orderbook.hpp"
+#include "trading/core/user.hpp"
+#include <gtest/gtest.h>
+
+using namespace trading::core;
+
+class MatchingEngineTest : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        matching_engine_ = std::make_unique<MatchingEngine>();
+        orderbook_ = std::make_shared<OrderBook>("AAPL");
+        matching_engine_->addOrderBook("AAPL", orderbook_);
+
+        // Create users with starting cash
+        buyer_ = std::make_shared<User>("user-001", 10000.0);
+        seller_ = std::make_shared<User>("user-002", 10000.0);
+
+        // Add users to matching engine
+        matching_engine_->addUser(buyer_);
+        matching_engine_->addUser(seller_);
+
+        // Give seller some initial position to sell
+        seller_->applyExecution(OrderSide::BUY, "AAPL", 100.0, 50.0, 0.0);
+    }
+
+    std::unique_ptr<MatchingEngine> matching_engine_;
+    std::shared_ptr<OrderBook> orderbook_;
+    std::shared_ptr<User> buyer_;
+    std::shared_ptr<User> seller_;
+};
+
+// Basic functionality tests
+TEST_F(MatchingEngineTest, InitialState) {
+    EXPECT_EQ(matching_engine_->getTotalTrades(), 0);
+    EXPECT_NEAR(matching_engine_->getTotalVolume(), 0.0, 1e-9);
+    EXPECT_EQ(matching_engine_->getOrderBook("AAPL"), orderbook_);
+    EXPECT_EQ(matching_engine_->getOrderBook("MSFT"), nullptr);
+}
+
+TEST_F(MatchingEngineTest, AddOrderBook) {
+    auto new_orderbook = std::make_shared<OrderBook>("MSFT");
+    matching_engine_->addOrderBook("MSFT", new_orderbook);
+    EXPECT_EQ(matching_engine_->getOrderBook("MSFT"), new_orderbook);
+}
+
+TEST_F(MatchingEngineTest, LimitOrderMatchingSamePriceBuyFirst) {
+    // Add buy order first
+    auto buy_order = std::make_shared<Order>("buy-1", "user-001", "AAPL", OrderType::LIMIT,
+                                             OrderSide::BUY, 100.0, 50.0);
+    orderbook_->addOrder(buy_order);
+
+    // Add matching sell order
+    auto sell_order = std::make_shared<Order>("sell-1", "user-002", "AAPL", OrderType::LIMIT,
+                                              OrderSide::SELL, 100.0, 50.0);
+    auto trades = matching_engine_->matchOrder(sell_order, *orderbook_);
+
+    ASSERT_EQ(trades.size(), 1);
+    EXPECT_EQ(trades[0].quantity, 100.0);
+    EXPECT_EQ(trades[0].price, 50.0);  // Should match at sell order's price
+    EXPECT_EQ(trades[0].buy_user_id, "user-001");
+    EXPECT_EQ(trades[0].sell_user_id, "user-002");
+
+    EXPECT_EQ(matching_engine_->getTotalTrades(), 1);
+    EXPECT_NEAR(matching_engine_->getTotalVolume(), 5000.0, 1e-9);
+}
+
+TEST_F(MatchingEngineTest, LimitOrderMatchingSamePriceSellFirst) {
+    // Add sell order first
+    auto sell_order = std::make_shared<Order>("sell-1", "user-002", "AAPL", OrderType::LIMIT,
+                                              OrderSide::SELL, 100.0, 50.0);
+    orderbook_->addOrder(sell_order);
+
+    // Add matching buy order
+    auto buy_order = std::make_shared<Order>("buy-1", "user-001", "AAPL", OrderType::LIMIT,
+                                             OrderSide::BUY, 100.0, 50.0);
+    auto trades = matching_engine_->matchOrder(buy_order, *orderbook_);
+
+    ASSERT_EQ(trades.size(), 1);
+    EXPECT_EQ(trades[0].quantity, 100.0);
+    EXPECT_EQ(trades[0].price, 50.0);  // Should match at buy order's price
+    EXPECT_EQ(trades[0].buy_user_id, "user-001");
+    EXPECT_EQ(trades[0].sell_user_id, "user-002");
+}
+
+TEST_F(MatchingEngineTest, LimitOrderPartialMatch) {
+    // Add large sell order
+    auto sell_order = std::make_shared<Order>("sell-1", "user-002", "AAPL", OrderType::LIMIT,
+                                              OrderSide::SELL, 200.0, 50.0);
+    orderbook_->addOrder(sell_order);
+
+    // Add smaller buy order
+    auto buy_order = std::make_shared<Order>("buy-1", "user-001", "AAPL", OrderType::LIMIT,
+                                             OrderSide::BUY, 75.0, 50.0);
+    auto trades = matching_engine_->matchOrder(buy_order, *orderbook_);
+
+    ASSERT_EQ(trades.size(), 1);
+    EXPECT_EQ(trades[0].quantity, 75.0);
+    EXPECT_EQ(trades[0].price, 50.0);
+
+    // Verify remaining quantity in sell order
+    EXPECT_NEAR(sell_order->getQuantity(), 125.0, 1e-9);
+}
+
+TEST_F(MatchingEngineTest, LimitOrderNoMatchWrongPrice) {
+    // Add high-priced sell order
+    auto sell_order = std::make_shared<Order>("sell-1", "user-002", "AAPL", OrderType::LIMIT,
+                                              OrderSide::SELL, 100.0, 60.0);
+    orderbook_->addOrder(sell_order);
+
+    // Add low-priced buy order (no match should occur)
+    auto buy_order = std::make_shared<Order>("buy-1", "user-001", "AAPL", OrderType::LIMIT,
+                                             OrderSide::BUY, 100.0, 50.0);
+    auto trades = matching_engine_->matchOrder(buy_order, *orderbook_);
+
+    EXPECT_EQ(trades.size(), 0);
+    EXPECT_EQ(matching_engine_->getTotalTrades(), 0);
+    EXPECT_NEAR(matching_engine_->getTotalVolume(), 0.0, 1e-9);
+}
+
+TEST_F(MatchingEngineTest, LimitOrderMultipleMatches) {
+    // Add multiple sell orders
+    auto sell_order1 = std::make_shared<Order>("sell-1", "user-002", "AAPL", OrderType::LIMIT,
+                                               OrderSide::SELL, 50.0, 49.0);
+    auto sell_order2 = std::make_shared<Order>("sell-2", "user-003", "AAPL", OrderType::LIMIT,
+                                               OrderSide::SELL, 75.0, 50.0);
+    orderbook_->addOrder(sell_order1);
+    orderbook_->addOrder(sell_order2);
+
+    // Add large buy order that should match both
+    auto buy_order = std::make_shared<Order>("buy-1", "user-001", "AAPL", OrderType::LIMIT,
+                                             OrderSide::BUY, 150.0, 50.0);
+    auto trades = matching_engine_->matchOrder(buy_order, *orderbook_);
+
+    EXPECT_EQ(trades.size(), 2);
+    EXPECT_EQ(matching_engine_->getTotalTrades(), 2);
+}
+
+TEST_F(MatchingEngineTest, MarketOrderMatchingBuy) {
+    // Add sell orders with different prices
+    auto sell_order1 = std::make_shared<Order>("sell-1", "user-002", "AAPL", OrderType::LIMIT,
+                                               OrderSide::SELL, 50.0, 49.0);
+    auto sell_order2 = std::make_shared<Order>("sell-2", "user-003", "AAPL", OrderType::LIMIT,
+                                               OrderSide::SELL, 75.0, 51.0);
+    orderbook_->addOrder(sell_order1);
+    orderbook_->addOrder(sell_order2);
+
+    // Market buy order should match at best ask (49.0)
+    auto market_buy = std::make_shared<Order>("buy-1", "user-001", "AAPL", OrderType::MARKET,
+                                              OrderSide::BUY, 100.0);
+    auto trades = matching_engine_->matchOrder(market_buy, *orderbook_);
+
+    EXPECT_GT(trades.size(), 0);
+    // Should match with the best ask price
+    if (!trades.empty()) {
+        EXPECT_EQ(trades[0].price, 49.0);
+    }
+}
+
+TEST_F(MatchingEngineTest, MarketOrderMatchingSell) {
+    // Add buy orders with different prices
+    auto buy_order1 = std::make_shared<Order>("buy-1", "user-001", "AAPL", OrderType::LIMIT,
+                                              OrderSide::BUY, 50.0, 52.0);
+    auto buy_order2 = std::make_shared<Order>("buy-2", "user-003", "AAPL", OrderType::LIMIT,
+                                              OrderSide::BUY, 75.0, 50.0);
+    orderbook_->addOrder(buy_order1);
+    orderbook_->addOrder(buy_order2);
+
+    // Market sell order should match at best bid (52.0)
+    auto market_sell = std::make_shared<Order>("sell-1", "user-002", "AAPL", OrderType::MARKET,
+                                               OrderSide::SELL, 100.0);
+    auto trades = matching_engine_->matchOrder(market_sell, *orderbook_);
+
+    EXPECT_GT(trades.size(), 0);
+    // Should match with the best bid price
+    if (!trades.empty()) {
+        EXPECT_EQ(trades[0].price, 52.0);
+    }
+}
+
+TEST_F(MatchingEngineTest, TradeCallbackFunctionality) {
+    bool callback_called = false;
+    std::vector<Trade> received_trades;
+
+    matching_engine_->setTradeCallback([&](const Trade& trade) {
+        callback_called = true;
+        received_trades.push_back(trade);
+    });
+
+    // Create matching orders
+    auto sell_order = std::make_shared<Order>("sell-1", "user-002", "AAPL", OrderType::LIMIT,
+                                              OrderSide::SELL, 100.0, 50.0);
+    orderbook_->addOrder(sell_order);
+
+    auto buy_order = std::make_shared<Order>("buy-1", "user-001", "AAPL", OrderType::LIMIT,
+                                             OrderSide::BUY, 100.0, 50.0);
+    auto trades = matching_engine_->matchOrder(buy_order, *orderbook_);
+
+    EXPECT_TRUE(callback_called);
+    EXPECT_EQ(received_trades.size(), 1);
+    EXPECT_EQ(received_trades[0].symbol, "AAPL");
+    EXPECT_EQ(received_trades[0].quantity, 100.0);
+    EXPECT_EQ(received_trades[0].price, 50.0);
+}
+
+// User portfolio update tests
+
+TEST_F(MatchingEngineTest, MatchingUpdatesUserPortfolios) {
+    // Initial state
+    EXPECT_NEAR(buyer_->getCashBalance(), 10000.0, 1e-9);
+    EXPECT_NEAR(seller_->getCashBalance(), 5000.0, 1e-9);  // 10000 - (100 * 50)
+
+    auto seller_position = seller_->getPosition("AAPL");
+    ASSERT_TRUE(seller_position.has_value());
+    EXPECT_NEAR(seller_position->quantity, 100.0, 1e-9);
+    EXPECT_NEAR(seller_position->average_price, 50.0, 1e-9);
+
+    // Create orders
+    auto sell_order = std::make_shared<Order>("sell-1", "user-002", "AAPL", OrderType::LIMIT,
+                                              OrderSide::SELL, 50.0, 60.0);
+    auto buy_order = std::make_shared<Order>("buy-1", "user-001", "AAPL", OrderType::LIMIT,
+                                             OrderSide::BUY, 50.0, 60.0);
+
+    // Add sell order first
+    orderbook_->addOrder(sell_order);
+
+    // Match buy order against sell order
+    auto trades = matching_engine_->matchOrder(buy_order, *orderbook_);
+
+    // Verify trade was created
+    ASSERT_EQ(trades.size(), 1);
+    EXPECT_EQ(trades[0].quantity, 50.0);
+    EXPECT_EQ(trades[0].price, 60.0);
+    EXPECT_EQ(trades[0].buy_user_id, "user-001");
+    EXPECT_EQ(trades[0].sell_user_id, "user-002");
+
+    // Verify buyer's portfolio updated
+    EXPECT_NEAR(buyer_->getCashBalance(), 10000.0 - (50.0 * 60.0), 1e-9);  // 10000 - 3000 = 7000
+    auto buyer_position = buyer_->getPosition("AAPL");
+    ASSERT_TRUE(buyer_position.has_value());
+    EXPECT_NEAR(buyer_position->quantity, 50.0, 1e-9);
+    EXPECT_NEAR(buyer_position->average_price, 60.0, 1e-9);
+
+    // Verify seller's portfolio updated
+    EXPECT_NEAR(seller_->getCashBalance(), 5000.0 + (50.0 * 60.0), 1e-9);  // 5000 + 3000 = 8000
+    seller_position = seller_->getPosition("AAPL");
+    ASSERT_TRUE(seller_position.has_value());
+    EXPECT_NEAR(seller_position->quantity, 50.0, 1e-9);       // 100 - 50 = 50
+    EXPECT_NEAR(seller_position->average_price, 50.0, 1e-9);  // unchanged
+
+    // Verify seller's realized PnL
+    double expected_pnl =
+        (50.0 * 60.0) - (50.0 * 50.0);  // proceeds - cost basis = 3000 - 2500 = 500
+    EXPECT_NEAR(seller_->getRealizedPnl(), expected_pnl, 1e-9);
+}
+
+TEST_F(MatchingEngineTest, TradeCallbackWithUserPortfolios) {
+    bool callback_called = false;
+    Trade received_trade;
+
+    // Set up callback to capture trade
+    matching_engine_->setTradeCallback([&](const Trade& trade) {
+        callback_called = true;
+        received_trade = trade;
+    });
+
+    // Create and match orders
+    auto sell_order = std::make_shared<Order>("sell-1", "user-002", "AAPL", OrderType::LIMIT,
+                                              OrderSide::SELL, 25.0, 55.0);
+    auto buy_order = std::make_shared<Order>("buy-1", "user-001", "AAPL", OrderType::MARKET,
+                                             OrderSide::BUY, 25.0);
+
+    orderbook_->addOrder(sell_order);
+    auto trades = matching_engine_->matchOrder(buy_order, *orderbook_);
+
+    // Verify callback was called
+    EXPECT_TRUE(callback_called);
+    ASSERT_EQ(trades.size(), 1);
+
+    // Verify trade data passed to callback
+    EXPECT_EQ(received_trade.quantity, 25.0);
+    EXPECT_EQ(received_trade.buy_user_id, "user-001");
+    EXPECT_EQ(received_trade.sell_user_id, "user-002");
+    EXPECT_EQ(received_trade.symbol, "AAPL");
+}
+
+TEST_F(MatchingEngineTest, UserRegistryFunctionality) {
+    // Test getOrCreateUser for existing user
+    auto existing_user = matching_engine_->getOrCreateUser("user-001");
+    EXPECT_EQ(existing_user->getUserId(), "user-001");
+    EXPECT_EQ(existing_user, buyer_);  // Should be the same instance
+
+    // Test getOrCreateUser for new user
+    auto new_user = matching_engine_->getOrCreateUser("user-003", 5000.0);
+    EXPECT_EQ(new_user->getUserId(), "user-003");
+    EXPECT_NEAR(new_user->getCashBalance(), 5000.0, 1e-9);
+
+    // Test getUser for existing and non-existing users
+    EXPECT_EQ(matching_engine_->getUser("user-001"), buyer_);
+    EXPECT_EQ(matching_engine_->getUser("user-999"), nullptr);
+}

--- a/tests/unit/test_user.cpp
+++ b/tests/unit/test_user.cpp
@@ -1,0 +1,122 @@
+#include "trading/core/order.hpp"
+#include "trading/core/user.hpp"
+#include <gtest/gtest.h>
+
+using namespace trading::core;
+
+class UserTest : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        starting_cash = 10000.0;
+        user = std::make_unique<User>("user-001", starting_cash);
+    }
+
+    double starting_cash;
+    std::unique_ptr<User> user;
+};
+
+TEST_F(UserTest, InitialState) {
+    EXPECT_EQ(user->getUserId(), "user-001");
+    EXPECT_NEAR(user->getCashBalance(), starting_cash, 1e-9);
+    EXPECT_NEAR(user->getRealizedPnl(), 0.0, 1e-12);
+    EXPECT_TRUE(user->getAllPositions().empty());
+}
+
+TEST_F(UserTest, DepositAndWithdrawCash) {
+    ASSERT_TRUE(user->depositCash(500.0));
+    EXPECT_NEAR(user->getCashBalance(), starting_cash + 500.0, 1e-9);
+
+    // Invalid deposit
+    EXPECT_FALSE(user->depositCash(0.0));
+    EXPECT_FALSE(user->depositCash(-10.0));
+    EXPECT_NEAR(user->getCashBalance(), starting_cash + 500.0, 1e-9);
+
+    // Valid withdrawal
+    ASSERT_TRUE(user->withdrawCash(300.0));
+    EXPECT_NEAR(user->getCashBalance(), starting_cash + 200.0, 1e-9);
+
+    // Invalid withdrawal
+    EXPECT_FALSE(user->withdrawCash(0.0));
+    EXPECT_FALSE(user->withdrawCash(-5.0));
+    EXPECT_FALSE(user->withdrawCash(starting_cash + 201.0));
+    EXPECT_NEAR(user->getCashBalance(), starting_cash + 200.0, 1e-9);
+}
+
+TEST_F(UserTest, ApplyExecutionBuyCreatesAndUpdatesPosition) {
+    // Buy 10 @ 100, fee 1.0
+    ASSERT_TRUE(user->applyExecution(OrderSide::BUY, "AAPL", 10.0, 100.0, 1.0));
+    EXPECT_NEAR(user->getCashBalance(), starting_cash - 1001.0, 1e-9);
+    auto pos_opt = user->getPosition("AAPL");
+    ASSERT_TRUE(pos_opt.has_value());
+    EXPECT_NEAR(pos_opt->quantity, 10.0, 1e-9);
+    EXPECT_NEAR(pos_opt->average_price, 100.0, 1e-12);
+    EXPECT_NEAR(user->getRealizedPnl(), 0.0, 1e-12);
+
+    // Buy additional 20 @ 110, fee 2.0
+    ASSERT_TRUE(user->applyExecution(OrderSide::BUY, "AAPL", 20.0, 110.0, 2.0));
+    EXPECT_NEAR(user->getCashBalance(), starting_cash - 1001.0 - 2202.0, 1e-9);
+    pos_opt = user->getPosition("AAPL");
+    ASSERT_TRUE(pos_opt.has_value());
+    EXPECT_NEAR(pos_opt->quantity, 30.0, 1e-9);
+    EXPECT_NEAR(pos_opt->average_price, (1000.0 + 2200.0) / 30.0, 1e-9);
+}
+
+TEST_F(UserTest, ApplyExecutionSellRealizesPnLAndReducesPosition) {
+    // Build position: 10 @ 100 (fee 1), then 20 @ 110 (fee 2)
+    ASSERT_TRUE(user->applyExecution(OrderSide::BUY, "AAPL", 10.0, 100.0, 1.0));
+    ASSERT_TRUE(user->applyExecution(OrderSide::BUY, "AAPL", 20.0, 110.0, 2.0));
+    const double avg_price = (1000.0 + 2200.0) / 30.0;  // 106.666...
+
+    // Sell 5 @ 120, fee 1
+    ASSERT_TRUE(user->applyExecution(OrderSide::SELL, "AAPL", 5.0, 120.0, 1.0));
+    auto pos_opt = user->getPosition("AAPL");
+    ASSERT_TRUE(pos_opt.has_value());
+    EXPECT_NEAR(pos_opt->quantity, 25.0, 1e-9);
+    EXPECT_NEAR(pos_opt->average_price, avg_price, 1e-9);  // unchanged on partial sell
+
+    // Realized PnL: (5*120 - 1) - 5*avg
+    double expected_pnl1 = (600.0 - 1.0) - 5.0 * avg_price;  // 599 - cost basis
+    EXPECT_NEAR(user->getRealizedPnl(), expected_pnl1, 1e-9);
+
+    // Sell remaining 25 @ 100, no fee
+    ASSERT_TRUE(user->applyExecution(OrderSide::SELL, "AAPL", 25.0, 100.0, 0.0));
+    pos_opt = user->getPosition("AAPL");
+    ASSERT_TRUE(pos_opt.has_value());
+    EXPECT_NEAR(pos_opt->quantity, 0.0, 1e-12);
+    EXPECT_NEAR(pos_opt->average_price, 0.0, 1e-12);  // reset when flat
+
+    // Total PnL should be -101.0 exactly with these numbers
+    EXPECT_NEAR(user->getRealizedPnl(), -101.0, 1e-9);
+}
+
+TEST_F(UserTest, ApplyExecutionFailsOnInsufficientCash) {
+    User low_cash_user("user-002", 100.0);
+    // Buying 1 @ 100 with fee 1 exceeds 100
+    EXPECT_FALSE(low_cash_user.applyExecution(OrderSide::BUY, "AAPL", 1.0, 100.0, 1.0));
+
+    // Trade should have no effect on user's cash balance because it failed
+    EXPECT_NEAR(low_cash_user.getCashBalance(), 100.0, 1e-12);
+
+    // User should have no positions
+    std::cout << "low_cash_user.getAllPositions().size(): "
+              << low_cash_user.getAllPositions().size() << std::endl;
+    EXPECT_TRUE(low_cash_user.getAllPositions().empty());
+}
+
+TEST_F(UserTest, ApplyExecutionFailsOnOversell) {
+    ASSERT_TRUE(user->applyExecution(OrderSide::BUY, "AAPL", 5.0, 10.0, 0.0));
+    // Attempt to sell more than owned
+    EXPECT_FALSE(user->applyExecution(OrderSide::SELL, "AAPL", 10.0, 10.0, 0.0));
+    auto pos_opt = user->getPosition("AAPL");
+    ASSERT_TRUE(pos_opt.has_value());
+    EXPECT_NEAR(pos_opt->quantity, 5.0, 1e-12);
+}
+
+TEST_F(UserTest, ApplyExecutionRejectsInvalidInputs) {
+    // Non-positive quantity
+    EXPECT_FALSE(user->applyExecution(OrderSide::BUY, "AAPL", 0.0, 100.0, 0.0));
+    EXPECT_FALSE(user->applyExecution(OrderSide::BUY, "AAPL", -1.0, 100.0, 0.0));
+    // Negative price or fee
+    EXPECT_FALSE(user->applyExecution(OrderSide::BUY, "AAPL", 1.0, -1.0, 0.0));
+    EXPECT_FALSE(user->applyExecution(OrderSide::BUY, "AAPL", 1.0, 100.0, -0.5));
+}


### PR DESCRIPTION
This pull request introduces user portfolio tracking and management to the trading engine. The main changes include adding a new `User` class to represent user portfolios, updating the matching engine to track users and update their portfolios after trades, and modifying the trade and matching logic to include user information. These changes enable the system to keep track of each user's cash balance, positions, and realized PnL as orders are matched and trades are executed.

**User portfolio management and tracking:**

* Added new `User` class and related types in `include/trading/core/user.hpp` and implemented user portfolio logic in `src/core/user.cpp`, including cash management, position tracking, and execution handling. [[1]](diffhunk://#diff-abeb0b80ad221f6f7dab28a8679f15b1b8a944f6361ac609b308d91f1de4a924R1-R64) [[2]](diffhunk://#diff-7035500961b81bdbe82c0e3713a7d74465a2aa848bb186bba91e4a5ecfa60e2eR1-R107)
* Updated `MatchingEngine` to maintain a registry of users, provide methods for adding/getting/creating users, and update user portfolios after each trade. [[1]](diffhunk://#diff-61f266406770daf29c9e35eca9043682148542d631ba9e5ec4002d6d8f8a0436R41-R46) [[2]](diffhunk://#diff-61f266406770daf29c9e35eca9043682148542d631ba9e5ec4002d6d8f8a0436R60-R68) [[3]](diffhunk://#diff-c67d3b939f17b771610234cd1881e4462442992703c72221f0c296a32e9c4e2aR185-R222)

**Trade and matching logic enhancements:**

* Modified `Trade` struct to include buyer and seller user IDs, and updated trade creation logic to set these fields. [[1]](diffhunk://#diff-61f266406770daf29c9e35eca9043682148542d631ba9e5ec4002d6d8f8a0436R19-R20) [[2]](diffhunk://#diff-c67d3b939f17b771610234cd1881e4462442992703c72221f0c296a32e9c4e2aR166-R167)
* Updated market and limit order matching functions to call `updateUserPortfolios` after each trade, ensuring user balances and positions are updated in real time. [[1]](diffhunk://#diff-c67d3b939f17b771610234cd1881e4462442992703c72221f0c296a32e9c4e2aL64-R69) [[2]](diffhunk://#diff-c67d3b939f17b771610234cd1881e4462442992703c72221f0c296a32e9c4e2aL78-R94) [[3]](diffhunk://#diff-c67d3b939f17b771610234cd1881e4462442992703c72221f0c296a32e9c4e2aL109-R127) [[4]](diffhunk://#diff-c67d3b939f17b771610234cd1881e4462442992703c72221f0c296a32e9c4e2aR145-R152)

**Configuration changes:**

* Added a `portfolio` section to `config/trading_engine.json` to specify starting cash for user portfolios.

**Other minor changes:**

* Included `user.hpp` in `matching_engine.hpp` for access to user-related types.
* Updated order handling in `TradingEngine` to log information about trades generated from matched orders.