### PR TITLE
Built HTTP Server Connection to Red Panda

### DIFF
--- a/include/trading/network/http_server.hpp
+++ b/include/trading/network/http_server.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <atomic>
 #include <functional>
 #include <map>
 #include <memory>
 #include <string>
+#include <thread>
 
 namespace trading {
 namespace network {
@@ -43,7 +45,7 @@ class HttpServer {
 
   private:
     std::string host_;
-    [[maybe_unused]] int port_;  // TODO: Use when implementing HTTP server
+    int port_;
     bool running_;
     int timeout_seconds_;
     int max_connections_;
@@ -53,6 +55,11 @@ class HttpServer {
 
     void handleRequest(const HttpRequest& request);
     HttpResponse createErrorResponse(int status_code, const std::string& message);
+
+    // Internal server state
+    int server_fd_ = -1;
+    std::thread server_thread_;
+    std::atomic<bool> stop_flag_{false};
 };
 
 }  // namespace network

--- a/scripts/run_simulation.sh
+++ b/scripts/run_simulation.sh
@@ -1,0 +1,379 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Throughput simulation for the trading engine.
+# - Starts a Redpanda (Kafka) container if not running
+# - Builds and runs the trading engine
+# - Sends a burst of orders (HTTP if available; otherwise directly to Kafka)
+# - Waits for processing to complete and reports throughput
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Defaults (overridable via env or flags)
+ORDERS_COUNT=${ORDERS_COUNT:-1000}
+CONCURRENCY=${CONCURRENCY:-100}
+USERS=${USERS:-10}
+SYMBOL=${SYMBOL:-AAPL}
+PRICE=${PRICE:-150.50}
+QTY=${QTY:-1.0}
+HTTP_HOST=${HTTP_HOST:-127.0.0.1}
+HTTP_PORT=${HTTP_PORT:-8080}
+HTTP_ORDERS_PATH=${HTTP_ORDERS_PATH:-/orders}
+HTTP_HEALTH_PATH=${HTTP_HEALTH_PATH:-/health}
+KAFKA_BROKERS=${KAFKA_BROKERS:-127.0.0.1:9092}
+TOPIC=${TOPIC:-order-requests}
+REDPANDA_CONTAINER_NAME=${REDPANDA_CONTAINER_NAME:-redpanda-sim}
+ENGINE_BIN_REL="build/apps/trading_engine/live_trading_engine"
+ENGINE_BIN="$REPO_ROOT/$ENGINE_BIN_REL"
+ENGINE_CONFIG_REL="config/trading_engine.json"
+ENGINE_CONFIG="$REPO_ROOT/$ENGINE_CONFIG_REL"
+APP_LOG="$REPO_ROOT/app.log"
+
+MODE="auto" # auto|http|queue
+KEEP_RED_PANDA=${KEEP_RED_PANDA:-0}
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [options]
+
+Options:
+  -n, --orders N          Total number of orders (default: $ORDERS_COUNT)
+  -c, --concurrency N     Concurrent clients (default: $CONCURRENCY)
+  -u, --users N           Distinct userIds to rotate (default: $USERS)
+  -s, --symbol SYM        Symbol (default: $SYMBOL)
+  -p, --price P           Price (default: $PRICE)
+  -q, --quantity Q        Quantity (default: $QTY)
+  --http-host HOST        HTTP host (default: $HTTP_HOST)
+  --http-port PORT        HTTP port (default: $HTTP_PORT)
+  --http-orders PATH      HTTP orders path (default: $HTTP_ORDERS_PATH)
+  --http-health PATH      HTTP health path (default: $HTTP_HEALTH_PATH)
+  --brokers HOST:PORT     Kafka brokers (default: $KAFKA_BROKERS)
+  -t, --topic NAME        Kafka topic (default: $TOPIC)
+  -m, --mode MODE         auto|http|queue (default: auto)
+  --keep-redpanda         Do not stop/remove Redpanda container after run
+  -h, --help              Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -n|--orders) ORDERS_COUNT="$2"; shift 2 ;;
+    -c|--concurrency) CONCURRENCY="$2"; shift 2 ;;
+    -u|--users) USERS="$2"; shift 2 ;;
+    -s|--symbol) SYMBOL="$2"; shift 2 ;;
+    -p|--price) PRICE="$2"; shift 2 ;;
+    -q|--quantity) QTY="$2"; shift 2 ;;
+    --http-host) HTTP_HOST="$2"; shift 2 ;;
+    --http-port) HTTP_PORT="$2"; shift 2 ;;
+    --http-orders) HTTP_ORDERS_PATH="$2"; shift 2 ;;
+    --http-health) HTTP_HEALTH_PATH="$2"; shift 2 ;;
+    --brokers) KAFKA_BROKERS="$2"; shift 2 ;;
+    -t|--topic) TOPIC="$2"; shift 2 ;;
+    -m|--mode) MODE="$2"; shift 2 ;;
+    --keep-redpanda) KEEP_RED_PANDA=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+has_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+start_redpanda() {
+  if docker ps --format '{{.Names}}' | grep -q "^${REDPANDA_CONTAINER_NAME}$"; then
+    echo "Redpanda container '${REDPANDA_CONTAINER_NAME}' already running"
+    return
+  fi
+
+  if docker ps -a --format '{{.Names}}' | grep -q "^${REDPANDA_CONTAINER_NAME}$"; then
+    docker rm -f "${REDPANDA_CONTAINER_NAME}" >/dev/null 2>&1 || true
+  fi
+
+  echo "Starting Redpanda container '${REDPANDA_CONTAINER_NAME}'..."
+  docker run -d --pull=always \
+    --name "${REDPANDA_CONTAINER_NAME}" \
+    -p 9092:9092 \
+    -p 9644:9644 \
+    redpandadata/redpanda:latest \
+    redpanda start \
+      --overprovisioned \
+      --smp 1 \
+      --memory 512M \
+      --reserve-memory 0M \
+      --node-id 0 \
+      --check=false \
+      --kafka-addr PLAINTEXT://0.0.0.0:9092 \
+      --advertise-kafka-addr PLAINTEXT://127.0.0.1:9092 >/dev/null
+
+  echo "Waiting for Redpanda to be ready..."
+  SECS=0
+  until docker logs "${REDPANDA_CONTAINER_NAME}" 2>&1 | grep -q "Started Kafka API server"; do
+    sleep 1
+    SECS=$((SECS+1))
+    if (( SECS > 30 )); then
+      echo "Timed out waiting for Redpanda to start" >&2
+      exit 1
+    fi
+  done
+
+  # Create the required topic
+  echo "Creating Kafka topic '${TOPIC}'..."
+  if has_cmd rpk; then
+    rpk topic create "${TOPIC}" --brokers="${KAFKA_BROKERS}" >/dev/null 2>&1 || true
+  else
+    docker exec "${REDPANDA_CONTAINER_NAME}" rpk topic create "${TOPIC}" >/dev/null 2>&1 || true
+  fi
+}
+
+build_engine() {
+  echo "Building trading engine (Release)..."
+  mkdir -p "$REPO_ROOT/build"
+  cmake -S "$REPO_ROOT" -B "$REPO_ROOT/build" -DCMAKE_BUILD_TYPE=Release >/dev/null
+  cmake --build "$REPO_ROOT/build" -j >/dev/null
+}
+
+run_engine() {
+  echo "Starting trading engine..."
+  # Clean previous logs to simplify counting
+  rm -f "$APP_LOG" "$REPO_ROOT/trading_engine.log" || true
+  echo "Command: $ENGINE_BIN $ENGINE_CONFIG"
+  ("$ENGINE_BIN" "$ENGINE_CONFIG") &
+  ENGINE_PID=$!
+
+  # Wait for engine to report started
+  echo -n "Waiting for engine to be ready"
+  for i in {1..60}; do
+    if [[ -f "$APP_LOG" ]] && grep -q "Trading engine started" "$APP_LOG"; then
+      # Also check if HTTP server is responding
+      if curl -s --connect-timeout 1 --max-time 1 "http://${HTTP_HOST}:${HTTP_PORT}${HTTP_HEALTH_PATH}" >/dev/null 2>&1; then
+        echo " - ready"
+        # Small delay to ensure server is fully stable
+        sleep 0.5
+        return 0
+      fi
+    fi
+    echo -n "."
+    sleep 0.5
+  done
+  echo
+  echo "Engine did not start successfully; check $APP_LOG" >&2
+  exit 1
+}
+
+stop_engine() {
+  if [[ -n "${ENGINE_PID:-}" ]] && ps -p "$ENGINE_PID" >/dev/null 2>&1; then
+    kill "$ENGINE_PID" >/dev/null 2>&1 || true
+    wait "$ENGINE_PID" 2>/dev/null || true
+  fi
+}
+
+cleanup() {
+  stop_engine || true
+  if [[ "$KEEP_RED_PANDA" != "1" ]]; then
+    docker rm -f "$REDPANDA_CONTAINER_NAME" >/dev/null 2>&1 || true
+  fi
+}
+
+require_cmd docker
+require_cmd cmake
+
+start_redpanda
+build_engine
+run_engine
+
+# Detect HTTP availability when in auto mode
+if [[ "$MODE" == "auto" ]]; then
+  if curl -sSf "http://${HTTP_HOST}:${HTTP_PORT}${HTTP_HEALTH_PATH}" >/dev/null 2>&1; then
+    MODE="http"
+  else
+    echo "HTTP endpoint not responding; will publish directly to Kafka"
+    MODE="queue"
+  fi
+fi
+
+echo "Mode: $MODE"
+
+generate_orders() {
+  local count="$1"
+  local users="$2"
+  local symbol="$3"
+  local price="$4"
+  local qty="$5"
+  local out_file="$6"
+
+  : > "$out_file"
+  local half=$((count/2))
+  for ((i=0;i<count;i++)); do
+    local user_idx=$(( (i % users) + 1 ))
+    local side
+    if (( i < half )); then side="SELL"; else side="BUY"; fi
+    local id="SIM_${i}"
+    local user_id="trader-${user_idx}"
+    local json
+    json=$(printf '{"id":"%s","userId":"%s","symbol":"%s","type":"LIMIT","side":"%s","quantity":%.6f,"price":%.2f}' \
+      "$id" "$user_id" "$symbol" "$side" "$qty" "$price")
+    echo "${user_id}|${json}" >> "$out_file"
+  done
+}
+
+# Prepare HTTP payloads into a file (one JSON per line)
+prepare_payloads_http() {
+  local count="$1"
+  local users="$2"
+  local symbol="$3"
+  local price="$4"
+  local qty="$5"
+  local out_file="$6"
+
+  : > "$out_file"
+  local half=$((count/2))
+  for ((i=0;i<count;i++)); do
+    local user_idx=$(( (i % users) + 1 ))
+    local side
+    if (( i < half )); then side="SELL"; else side="BUY"; fi
+    local id="SIM_${i}"
+    local user_id="trader-${user_idx}"
+    printf '%s\n' \
+      "$(printf '{"id":"%s","userId":"%s","symbol":"%s","type":"LIMIT","side":"%s","quantity":%.6f,"price":%.2f}' \
+        "$id" "$user_id" "$symbol" "$side" "$qty" "$price")" >> "$out_file"
+  done
+}
+
+produce_with_kcat() {
+  local input_file="$1"
+  if has_cmd kcat; then
+    kcat -b "$KAFKA_BROKERS" -t "$TOPIC" -K '|' < "$input_file"
+  else
+    docker run --rm -i --network host edenhill/kcat:1.7.1 \
+      -b "$KAFKA_BROKERS" -t "$TOPIC" -K '|' < "$input_file"
+  fi
+}
+
+send_orders_http() {
+  local payload_file="$1"
+  local concurrency="$2"
+  echo "Sending HTTP orders with concurrency $concurrency..."
+  LAST_HTTP_STATUS_FILE=$(mktemp)
+  
+  # Send each request sequentially with timeout to debug
+  local count=0
+  while IFS= read -r payload; do
+    echo "Sending order $((count + 1))..."
+    timeout 5s curl -s -o /dev/null -w "%{http_code}\n" \
+      -X POST -H "Content-Type: application/json" \
+      --connect-timeout 2 --max-time 3 \
+      "http://${HTTP_HOST}:${HTTP_PORT}${HTTP_ORDERS_PATH}" \
+      -d "$payload" >> "$LAST_HTTP_STATUS_FILE" || echo "000" >> "$LAST_HTTP_STATUS_FILE"
+    count=$((count + 1))
+  done < "$payload_file"
+  
+  echo "All HTTP requests completed"
+}
+
+wait_until_processed() {
+  local expected="$1"
+  local timeout_sec=${2:-60}
+  local waited=0
+  echo -n "Waiting for $expected orders to be processed"
+  while (( waited < timeout_sec )); do
+    if [[ -f "$APP_LOG" ]]; then
+      # Count lines that indicate an order was picked up from queue
+      local processed
+      processed=$(grep -c "Processing order from" "$APP_LOG" || true)
+      if (( processed >= expected )); then
+        echo " - done ($processed)"
+        return 0
+      fi
+    fi
+    echo -n "."
+    sleep 1
+    waited=$((waited+1))
+  done
+  echo
+  echo "Timed out waiting for orders to be processed. Check $APP_LOG" >&2
+}
+
+sum_trades() {
+  if [[ -f "$APP_LOG" ]]; then
+    # Sum numbers in lines like: "generated X trades"
+    awk '/generated [0-9]+ trades/ { for (i=1;i<=NF;i++) if ($i ~ /^[0-9]+$/) sum+=$i } END { print sum+0 }' "$APP_LOG"
+  else
+    echo 0
+  fi
+}
+
+EXPECTED_PROCESSED=$ORDERS_COUNT
+HTTP_SUCCESS_COUNT=0
+HTTP_FAIL_COUNT=0
+
+case "$MODE" in
+  http)
+    echo "Generating HTTP payloads..."
+    tmp_payloads=$(mktemp)
+    prepare_payloads_http "$ORDERS_COUNT" "$USERS" "$SYMBOL" "$PRICE" "$QTY" "$tmp_payloads"
+    echo "Starting to send $ORDERS_COUNT orders via HTTP..."
+    START_TS=$(date +%s%3N)
+    send_orders_http "$tmp_payloads" "$CONCURRENCY"
+    echo "Finished sending orders"
+    # Evaluate HTTP status codes (202 is success)
+    if [[ -n "${LAST_HTTP_STATUS_FILE:-}" && -f "$LAST_HTTP_STATUS_FILE" ]]; then
+      HTTP_SUCCESS_COUNT=$(grep -c '^202$' "$LAST_HTTP_STATUS_FILE" || true)
+      total_sent=$(wc -l < "$LAST_HTTP_STATUS_FILE" || echo 0)
+      HTTP_FAIL_COUNT=$(( total_sent - HTTP_SUCCESS_COUNT ))
+      EXPECTED_PROCESSED=$HTTP_SUCCESS_COUNT
+    fi
+    rm -f "$tmp_payloads"
+    ;;
+  queue)
+    echo "Generating Kafka orders..."
+    tmp_orders=$(mktemp)
+    generate_orders "$ORDERS_COUNT" "$USERS" "$SYMBOL" "$PRICE" "$QTY" "$tmp_orders"
+    echo "Starting to send $ORDERS_COUNT orders via Kafka..."
+    START_TS=$(date +%s%3N)
+    produce_with_kcat "$tmp_orders"
+    echo "Finished sending orders"
+    rm -f "$tmp_orders"
+    ;;
+  *) echo "Invalid MODE: $MODE" >&2; exit 1 ;;
+esac
+
+echo "Starting to wait for processing..."
+wait_until_processed "$EXPECTED_PROCESSED" 120
+echo "Finished waiting for processing"
+END_TS=$(date +%s%3N)
+
+duration_ms=$((END_TS - START_TS))
+duration_s=$(awk "BEGIN { printf \"%.3f\", $duration_ms/1000 }")
+orders_per_sec=$(awk "BEGIN { if ($duration_ms>0) printf \"%.2f\", ($ORDERS_COUNT*1000)/$duration_ms; else print 0 }")
+trades_total=$(sum_trades)
+trades_per_sec=$(awk "BEGIN { if ($duration_ms>0) printf \"%.2f\", ($trades_total*1000)/$duration_ms; else print 0 }")
+
+echo ""
+echo "===== Simulation Results ====="
+echo "Orders sent        : $ORDERS_COUNT"
+echo "Processed orders   : $(grep -c "Processing order from" "$APP_LOG" || echo 0)"
+if [[ "$MODE" == "http" ]]; then
+  echo "HTTP 202 count     : $HTTP_SUCCESS_COUNT"
+  echo "HTTP fail count    : $HTTP_FAIL_COUNT"
+fi
+echo "Trades executed    : $trades_total"
+echo "Duration (s)       : $duration_s"
+echo "Orders/sec         : $orders_per_sec"
+echo "Trades/sec         : $trades_per_sec"
+echo "Log file           : $APP_LOG"
+echo "================================"
+
+
+
+# Clean up
+cleanup

--- a/src/network/http_server.cpp
+++ b/src/network/http_server.cpp
@@ -1,7 +1,46 @@
+// Minimal HTTP server using POSIX sockets. Not production-grade.
+
 #include "trading/network/http_server.hpp"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <sstream>
 
 namespace trading {
 namespace network {
+
+namespace {
+std::string reasonPhrase(int status) {
+    switch (status) {
+        case 200:
+            return "OK";
+        case 202:
+            return "Accepted";
+        case 400:
+            return "Bad Request";
+        case 404:
+            return "Not Found";
+        case 500:
+            return "Internal Server Error";
+        default:
+            return "OK";
+    }
+}
+
+static void setSocketTimeout(int fd, int seconds) {
+    timeval tv{};
+    tv.tv_sec = seconds;
+    tv.tv_usec = 0;
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+}
+}  // namespace
 
 HttpServer::HttpServer(const std::string& host, int port)
     : host_(host), port_(port), running_(false), timeout_seconds_(30), max_connections_(100) {
@@ -14,13 +53,249 @@ HttpServer::~HttpServer() {
 }
 
 bool HttpServer::start() {
-    // TODO: Implement HTTP server startup
+    if (running_)
+        return true;
+
+    // Resolve host and bind
+    struct addrinfo hints {};
+    struct addrinfo* res = nullptr;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;  // IPv4
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_PASSIVE;  // for binding
+
+    std::string port_str = std::to_string(port_);
+    int rc =
+        getaddrinfo(host_ == "0.0.0.0" ? nullptr : host_.c_str(), port_str.c_str(), &hints, &res);
+    if (rc != 0 || !res) {
+        return false;
+    }
+
+    server_fd_ = ::socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+    if (server_fd_ < 0) {
+        freeaddrinfo(res);
+        return false;
+    }
+
+    int yes = 1;
+    setsockopt(server_fd_, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+
+    if (::bind(server_fd_, res->ai_addr, res->ai_addrlen) < 0) {
+        ::close(server_fd_);
+        server_fd_ = -1;
+        freeaddrinfo(res);
+        return false;
+    }
+    freeaddrinfo(res);
+
+    if (::listen(server_fd_, max_connections_ > 0 ? max_connections_ : 100) < 0) {
+        ::close(server_fd_);
+        server_fd_ = -1;
+        return false;
+    }
+
+    stop_flag_ = false;
     running_ = true;
+
+    server_thread_ = std::thread([this]() {
+        setSocketTimeout(server_fd_, timeout_seconds_);
+        while (!stop_flag_) {
+            struct sockaddr_in client_addr {};
+            socklen_t addr_len = sizeof(client_addr);
+            int client_fd =
+                ::accept(server_fd_, reinterpret_cast<struct sockaddr*>(&client_addr), &addr_len);
+            if (client_fd < 0) {
+                if (stop_flag_)
+                    break;
+                // EAGAIN/EINTR handled by continuing loop
+                continue;
+            }
+
+            setSocketTimeout(client_fd, timeout_seconds_);
+
+            // Read request into buffer
+            std::string request_raw;
+            char buf[4096];
+            ssize_t n;
+            bool headers_done = false;
+            size_t content_length = 0;
+            bool has_content_length = false;
+
+            while ((n = ::recv(client_fd, buf, sizeof(buf), 0)) > 0) {
+                request_raw.append(buf, buf + n);
+                if (!headers_done) {
+                    auto pos = request_raw.find("\r\n\r\n");
+                    if (pos != std::string::npos) {
+                        headers_done = true;
+                        // Parse Content-Length if present
+                        std::string headers = request_raw.substr(0, pos + 4);
+                        std::istringstream hs(headers);
+                        std::string line;
+                        std::getline(hs, line);  // request line
+                        while (std::getline(hs, line)) {
+                            if (line == "\r")
+                                break;
+                            auto colon = line.find(":");
+                            if (colon != std::string::npos) {
+                                std::string key = line.substr(0, colon);
+                                std::string value = line.substr(colon + 1);
+                                // trim
+                                while (!value.empty() && (value.front() == ' '))
+                                    value.erase(value.begin());
+                                if (!value.empty() && value.back() == '\r')
+                                    value.pop_back();
+                                for (auto& c : key)
+                                    c = std::tolower(c);
+                                if (key == "content-length") {
+                                    content_length = static_cast<size_t>(std::stoul(value));
+                                    has_content_length = true;
+                                }
+                            }
+                        }
+
+                        // Check if body already fully received
+                        size_t body_received = request_raw.size() - (pos + 4);
+                        if (has_content_length) {
+                            while (body_received < content_length) {
+                                n = ::recv(client_fd, buf, sizeof(buf), 0);
+                                if (n <= 0) {
+                                    // Check if this was a timeout or error
+                                    if (n == 0) {
+                                        // Connection closed by client
+                                        break;
+                                    } else if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK ||
+                                                         errno == ETIMEDOUT)) {
+                                        // Timeout occurred - close connection and skip processing
+                                        ::close(client_fd);
+                                        n = -1;  // Mark for skipping
+                                        break;
+                                    } else {
+                                        // Other error - break and try to process what we have
+                                        break;
+                                    }
+                                }
+                                request_raw.append(buf, buf + n);
+                                body_received += static_cast<size_t>(n);
+                            }
+                        }
+                        break;  // we have headers + body (or as much as available)
+                    }
+                } else {
+                    // If headers are done and we don't have content-length, assume body is complete
+                    if (!has_content_length) {
+                        break;
+                    }
+                }
+            }
+
+            // Check if the main recv loop exited due to timeout or error
+            if (n <= 0) {
+                if (n == 0) {
+                    // Connection closed cleanly
+                    ::close(client_fd);
+                    continue;
+                } else if (errno == EAGAIN || errno == EWOULDBLOCK || errno == ETIMEDOUT) {
+                    // Timeout occurred
+                    ::close(client_fd);
+                    continue;
+                }
+                // For other errors, try to process what we have (if any)
+                if (request_raw.empty()) {
+                    ::close(client_fd);
+                    continue;
+                }
+            }
+
+            // If we got here with n == -1 (timeout in Content-Length reading), skip processing
+            if (n == -1) {
+                continue;
+            }
+
+            // Parse request line and headers
+            HttpRequest req;
+            req.method = "GET";
+            req.path = "/";
+            size_t header_end = request_raw.find("\r\n\r\n");
+            if (header_end != std::string::npos) {
+                std::string head = request_raw.substr(0, header_end);
+                std::istringstream hs(head);
+                std::string request_line;
+                std::getline(hs, request_line);
+                if (!request_line.empty() && request_line.back() == '\r')
+                    request_line.pop_back();
+                {
+                    std::istringstream rl(request_line);
+                    rl >> req.method >> req.path;  // ignore HTTP version
+                }
+                std::string line;
+                while (std::getline(hs, line)) {
+                    if (line == "\r" || line.empty())
+                        break;
+                    if (!line.empty() && line.back() == '\r')
+                        line.pop_back();
+                    auto colon = line.find(":");
+                    if (colon != std::string::npos) {
+                        std::string key = line.substr(0, colon);
+                        std::string value = line.substr(colon + 1);
+                        while (!value.empty() && value.front() == ' ')
+                            value.erase(value.begin());
+                        req.headers[key] = value;
+                    }
+                }
+                req.body = request_raw.substr(header_end + 4);
+            }
+
+            // Route
+            HttpResponse resp;
+            bool handled = false;
+            if (req.path == "/health" && health_handler_) {
+                resp = health_handler_(req);
+                handled = true;
+            } else if (req.path == "/orders" && order_handler_) {
+                resp = order_handler_(req);
+                handled = true;
+            }
+            if (!handled) {
+                resp = createErrorResponse(404, "Not Found");
+            }
+
+            // Ensure Content-Type header
+            if (resp.headers.find("Content-Type") == resp.headers.end()) {
+                resp.headers["Content-Type"] = "application/json";
+            }
+
+            // Write response
+            std::ostringstream out;
+            out << "HTTP/1.1 " << resp.status_code << ' ' << reasonPhrase(resp.status_code)
+                << "\r\n";
+            out << "Content-Length: " << resp.body.size() << "\r\n";
+            for (const auto& kv : resp.headers) {
+                out << kv.first << ": " << kv.second << "\r\n";
+            }
+            out << "\r\n";
+            out << resp.body;
+            auto out_str = out.str();
+            ::send(client_fd, out_str.data(), out_str.size(), 0);
+
+            ::close(client_fd);
+        }
+    });
+
     return true;
 }
 
 void HttpServer::stop() {
-    // TODO: Implement HTTP server shutdown
+    if (!running_)
+        return;
+    stop_flag_ = true;
+    if (server_fd_ >= 0) {
+        ::shutdown(server_fd_, SHUT_RDWR);
+        ::close(server_fd_);
+        server_fd_ = -1;
+    }
+    if (server_thread_.joinable()) {
+        server_thread_.join();
+    }
     running_ = false;
 }
 
@@ -45,8 +320,7 @@ void HttpServer::setMaxConnections(int max_connections) {
 }
 
 void HttpServer::handleRequest(const HttpRequest& request) {
-    (void)request;  // Suppress unused parameter warning
-    // TODO: Implement request routing and handling
+    (void)request;  // Unused in this minimal implementation
 }
 
 HttpResponse HttpServer::createErrorResponse(int status_code, const std::string& message) {

--- a/tests/integration/test_pipeline_mock.cpp
+++ b/tests/integration/test_pipeline_mock.cpp
@@ -649,6 +649,8 @@ TEST_F(PipelineMockTest, PipelinePerformanceTest) {
     std::cout << "  Total Time: " << total_duration.count() << "ms" << std::endl;
     std::cout << "  Orders/sec: " << (NUM_ORDERS * 1000.0 / total_duration.count()) << std::endl;
     std::cout << "  Trades Generated: " << trade_count_ << std::endl;
+    std::cout << "  Trades/sec: " << (trade_count_ * 1000.0 / processing_duration.count())
+              << std::endl;
     std::cout << "  Total Volume: $" << total_volume_ << std::endl;
 
     EXPECT_EQ(processed_orders_, NUM_ORDERS);

--- a/tests/unit/test_http_server.cpp
+++ b/tests/unit/test_http_server.cpp
@@ -1,0 +1,301 @@
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+#include <arpa/inet.h>
+#include <gtest/gtest.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "trading/network/http_server.hpp"
+
+using namespace trading::network;
+
+class HttpServerTest : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        server_ = std::make_unique<HttpServer>("127.0.0.1", 8081);
+
+        // Set up handlers
+        server_->setHealthHandler([](const HttpRequest& req) -> HttpResponse {
+            (void)req;  // Suppress unused parameter warning
+            HttpResponse resp;
+            resp.status_code = 200;
+            resp.body = R"({"status": "healthy", "running": true})";
+            resp.headers["Content-Type"] = "application/json";
+            return resp;
+        });
+
+        server_->setOrderHandler([](const HttpRequest& req) -> HttpResponse {
+            (void)req;  // Suppress unused parameter warning
+            HttpResponse resp;
+            resp.status_code = 202;
+            resp.body = R"({"message": "Order received", "id": "test-order"})";
+            resp.headers["Content-Type"] = "application/json";
+            return resp;
+        });
+    }
+
+    void TearDown() override {
+        if (server_ && server_->isRunning()) {
+            server_->stop();
+        }
+        server_.reset();
+    }
+
+    // Helper function to send HTTP request via raw socket
+    std::string sendHttpRequest(const std::string& request) {
+        int sock = socket(AF_INET, SOCK_STREAM, 0);
+        if (sock < 0) {
+            return "ERROR: Could not create socket";
+        }
+
+        struct sockaddr_in server_addr {};
+        server_addr.sin_family = AF_INET;
+        server_addr.sin_port = htons(8081);
+        server_addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+
+        if (connect(sock, (struct sockaddr*)&server_addr, sizeof(server_addr)) < 0) {
+            close(sock);
+            return "ERROR: Could not connect";
+        }
+
+        // Send request
+        send(sock, request.c_str(), request.length(), 0);
+
+        // Read response
+        std::string response;
+        char buffer[4096];
+        int bytes_received;
+        while ((bytes_received = recv(sock, buffer, sizeof(buffer) - 1, 0)) > 0) {
+            buffer[bytes_received] = '\0';
+            response += buffer;
+            // Simple check to see if we got a complete HTTP response
+            if (response.find("\r\n\r\n") != std::string::npos) {
+                // Check if we need to read more based on Content-Length
+                auto cl_pos = response.find("Content-Length:");
+                if (cl_pos != std::string::npos) {
+                    auto cl_end = response.find("\r\n", cl_pos);
+                    if (cl_end != std::string::npos) {
+                        std::string cl_str = response.substr(cl_pos + 15, cl_end - cl_pos - 15);
+                        // Simple trim
+                        while (!cl_str.empty() && cl_str[0] == ' ')
+                            cl_str.erase(0, 1);
+                        int content_length = std::stoi(cl_str);
+
+                        auto body_start = response.find("\r\n\r\n") + 4;
+                        int body_length = response.length() - body_start;
+
+                        if (body_length >= content_length) {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        close(sock);
+        return response;
+    }
+
+    std::unique_ptr<HttpServer> server_;
+};
+
+TEST_F(HttpServerTest, ServerStartAndStop) {
+    EXPECT_FALSE(server_->isRunning());
+
+    EXPECT_TRUE(server_->start());
+    EXPECT_TRUE(server_->isRunning());
+
+    // Give server a moment to fully start
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    server_->stop();
+    EXPECT_FALSE(server_->isRunning());
+}
+
+TEST_F(HttpServerTest, HealthEndpoint) {
+    ASSERT_TRUE(server_->start());
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    std::string request =
+        "GET /health HTTP/1.1\r\n"
+        "Host: 127.0.0.1:8081\r\n"
+        "Connection: close\r\n"
+        "\r\n";
+
+    std::string response = sendHttpRequest(request);
+
+    EXPECT_NE(response.find("HTTP/1.1 200 OK"), std::string::npos);
+    EXPECT_NE(response.find("Content-Type: application/json"), std::string::npos);
+    EXPECT_NE(response.find(R"({"status": "healthy", "running": true})"), std::string::npos);
+}
+
+TEST_F(HttpServerTest, OrderEndpointWithContentLength) {
+    ASSERT_TRUE(server_->start());
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    std::string json_body =
+        R"({"id":"TEST_1","userId":"trader-1","symbol":"AAPL","type":"LIMIT","side":"BUY","quantity":1.0,"price":150.50})";
+    std::string request =
+        "POST /orders HTTP/1.1\r\n"
+        "Host: 127.0.0.1:8081\r\n"
+        "Content-Type: application/json\r\n"
+        "Content-Length: " +
+        std::to_string(json_body.length()) +
+        "\r\n"
+        "Connection: close\r\n"
+        "\r\n" +
+        json_body;
+
+    std::string response = sendHttpRequest(request);
+
+    EXPECT_NE(response.find("HTTP/1.1 202 Accepted"), std::string::npos);
+    EXPECT_NE(response.find("Content-Type: application/json"), std::string::npos);
+    EXPECT_NE(response.find(R"({"message": "Order received", "id": "test-order"})"),
+              std::string::npos);
+}
+
+TEST_F(HttpServerTest, OrderEndpointWithoutContentLength) {
+    ASSERT_TRUE(server_->start());
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    std::string json_body =
+        R"({"id":"TEST_2","userId":"trader-2","symbol":"MSFT","type":"LIMIT","side":"SELL","quantity":2.0,"price":300.00})";
+    std::string request =
+        "POST /orders HTTP/1.1\r\n"
+        "Host: 127.0.0.1:8081\r\n"
+        "Content-Type: application/json\r\n"
+        "Connection: close\r\n"
+        "\r\n" +
+        json_body;
+
+    std::string response = sendHttpRequest(request);
+
+    // This test specifically checks that the server doesn't hang when no Content-Length is provided
+    EXPECT_NE(response.find("HTTP/1.1 202 Accepted"), std::string::npos);
+    EXPECT_NE(response.find("Content-Type: application/json"), std::string::npos);
+}
+
+TEST_F(HttpServerTest, NotFoundEndpoint) {
+    ASSERT_TRUE(server_->start());
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    std::string request =
+        "GET /unknown HTTP/1.1\r\n"
+        "Host: 127.0.0.1:8081\r\n"
+        "Connection: close\r\n"
+        "\r\n";
+
+    std::string response = sendHttpRequest(request);
+
+    EXPECT_NE(response.find("HTTP/1.1 404 Not Found"), std::string::npos);
+    EXPECT_NE(response.find("Content-Type: application/json"), std::string::npos);
+    EXPECT_NE(response.find(R"({"error": "Not Found"})"), std::string::npos);
+}
+
+TEST_F(HttpServerTest, MultipleSimultaneousRequests) {
+    ASSERT_TRUE(server_->start());
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    const int num_requests = 5;
+    std::vector<std::thread> threads;
+    std::atomic<int> success_count{0};
+
+    for (int i = 0; i < num_requests; ++i) {
+        threads.emplace_back([this, i, &success_count]() {
+            std::string json_body =
+                R"({"id":"TEST_)" + std::to_string(i) + R"(","userId":"trader-)" +
+                std::to_string(i) +
+                R"(","symbol":"AAPL","type":"LIMIT","side":"BUY","quantity":1.0,"price":150.50})";
+            std::string request =
+                "POST /orders HTTP/1.1\r\n"
+                "Host: 127.0.0.1:8081\r\n"
+                "Content-Type: application/json\r\n"
+                "Content-Length: " +
+                std::to_string(json_body.length()) +
+                "\r\n"
+                "Connection: close\r\n"
+                "\r\n" +
+                json_body;
+
+            std::string response = sendHttpRequest(request);
+            if (response.find("HTTP/1.1 202 Accepted") != std::string::npos) {
+                success_count++;
+            }
+        });
+    }
+
+    // Wait for all threads to complete with timeout
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    // All requests should succeed
+    EXPECT_EQ(success_count.load(), num_requests);
+}
+
+TEST_F(HttpServerTest, RequestTimeout) {
+    // Set a short timeout
+    server_->setTimeout(2);
+    ASSERT_TRUE(server_->start());
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    // Create a socket but don't send the complete request
+    int sock = socket(AF_INET, SOCK_STREAM, 0);
+    ASSERT_GE(sock, 0);
+
+    struct sockaddr_in server_addr {};
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_port = htons(8081);
+    server_addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+
+    ASSERT_EQ(connect(sock, (struct sockaddr*)&server_addr, sizeof(server_addr)), 0);
+
+    // Send incomplete request
+    std::string incomplete_request =
+        "POST /orders HTTP/1.1\r\n"
+        "Host: 127.0.0.1:8081\r\n"
+        "Content-Length: 1000\r\n"
+        "\r\n";
+    send(sock, incomplete_request.c_str(), incomplete_request.length(), 0);
+
+    // Wait longer than the timeout
+    std::this_thread::sleep_for(std::chrono::seconds(3));
+
+    // The server should have closed the connection due to timeout
+    char buffer[1];
+    int result = recv(sock, buffer, sizeof(buffer), MSG_DONTWAIT);
+    EXPECT_EQ(result, 0);  // Connection should be closed
+
+    close(sock);
+}
+
+TEST_F(HttpServerTest, LargeRequestBody) {
+    ASSERT_TRUE(server_->start());
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    // Create a large JSON body (but reasonable size)
+    std::string large_field(1000, 'A');  // 1KB of 'A' characters
+    std::string json_body =
+        R"({"id":"TEST_LARGE","userId":"trader-large","symbol":"AAPL","type":"LIMIT","side":"BUY","quantity":1.0,"price":150.50,"large_field":")" +
+        large_field + R"("})";
+
+    std::string request =
+        "POST /orders HTTP/1.1\r\n"
+        "Host: 127.0.0.1:8081\r\n"
+        "Content-Type: application/json\r\n"
+        "Content-Length: " +
+        std::to_string(json_body.length()) +
+        "\r\n"
+        "Connection: close\r\n"
+        "\r\n" +
+        json_body;
+
+    std::string response = sendHttpRequest(request);
+
+    EXPECT_NE(response.find("HTTP/1.1 202 Accepted"), std::string::npos);
+    EXPECT_NE(response.find("Content-Type: application/json"), std::string::npos);
+}


### PR DESCRIPTION
This pull request introduces a minimal, working HTTP server implementation for the trading engine using POSIX sockets. It replaces the previous placeholders with actual server startup, request handling, and shutdown logic. Additionally, it adds a comprehensive simulation script (`run_simulation.sh`) to automate throughput testing of the engine via HTTP or Kafka. The most important changes are grouped below:

### HTTP Server Implementation

* Added a basic HTTP server using POSIX sockets in `src/network/http_server.cpp`, including connection handling, request parsing, routing (`/health`, `/orders`), and response generation. This replaces previous TODOs and enables real HTTP-based interactions. [[1]](diffhunk://#diff-c933a26d662f154cd89f7d4c97369f40b7f85ad55c810a73cf62af260dbf44f8R1-R44) [[2]](diffhunk://#diff-c933a26d662f154cd89f7d4c97369f40b7f85ad55c810a73cf62af260dbf44f8L17-R298)
* Updated the `HttpServer` class in `include/trading/network/http_server.hpp` to include server state variables (`server_fd_`, `server_thread_`, `stop_flag_`) and removed the `[[maybe_unused]]` annotation from `port_`. [[1]](diffhunk://#diff-40a7d0b0d456a06c3dc6c11cf855f334cc84f5f69b6e1fda1927377e2c9c7a79R3-R8) [[2]](diffhunk://#diff-40a7d0b0d456a06c3dc6c11cf855f334cc84f5f69b6e1fda1927377e2c9c7a79L46-R48) [[3]](diffhunk://#diff-40a7d0b0d456a06c3dc6c11cf855f334cc84f5f69b6e1fda1927377e2c9c7a79R58-R62)

### Simulation and Testing Automation

* Added `scripts/run_simulation.sh`, a full-featured script to build the engine, start Redpanda (Kafka), send bursts of orders via HTTP or Kafka, and report throughput metrics. It handles environment setup, order generation, and result summarization.

### Codebase Cleanups

* Removed unused code and placeholder comments in the HTTP server implementation, streamlining the code and clarifying where request handling occurs.