### PR TITLE
Added HTTP endpoint for leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,82 @@ Content-Type: application/json
 }
 ```
 
+#### Get Leaderboard
+Retrieve a live leaderboard ranking users by net worth (cash + portfolio value at current market prices).
+
+**Request:**
+```http
+GET /api/v1/leaderboard
+```
+
+**Response:**
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "timestamp": 1692633600,
+  "total_users": 50,
+  "leaderboard": [
+    {
+      "rank": 1,
+      "user_id": "trader_001",
+      "net_worth": 125750.50,
+      "cash_balance": 25000.00,
+      "portfolio_value": 100750.50,
+      "realized_pnl": 5750.50,
+      "positions": [
+        {
+          "symbol": "AAPL",
+          "quantity": 500.0,
+          "average_price": 145.20,
+          "current_price": 150.75,
+          "market_value": 75375.00,
+          "unrealized_pnl": 2775.00
+        },
+        {
+          "symbol": "MSFT",
+          "quantity": 75.0,
+          "average_price": 330.00,
+          "current_price": 335.50,
+          "market_value": 25162.50,
+          "unrealized_pnl": 412.50
+        }
+      ]
+    },
+    {
+      "rank": 2,
+      "user_id": "trader_002",
+      "net_worth": 98250.25,
+      "cash_balance": 15000.00,
+      "portfolio_value": 83250.25,
+      "realized_pnl": -1749.75,
+      "positions": [
+        {
+          "symbol": "GOOGL",
+          "quantity": 50.0,
+          "average_price": 2850.00,
+          "current_price": 2875.25,
+          "market_value": 143762.50,
+          "unrealized_pnl": 1262.50
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Response Fields:**
+- `rank` - User's position on the leaderboard (1 = highest net worth)
+- `net_worth` - Total value (cash + portfolio at current market prices)
+- `cash_balance` - Available cash balance
+- `portfolio_value` - Total value of all positions at current market prices
+- `realized_pnl` - Cumulative realized profit/loss from closed positions
+- `positions` - Array of current holdings with market valuations
+  - `current_price` - Current market price (mid-price from order book, or cost basis if no market data)
+  - `market_value` - Position value at current market price
+  - `unrealized_pnl` - Paper profit/loss relative to average purchase price
+
 #### Health Check
 Check the health and status of the trading engine.
 
@@ -434,6 +510,10 @@ print(all_stats.json())
 # Get market summary
 summary = requests.get('http://<trading-engine-host>:8080/api/v1/stats/summary')
 print(summary.json())
+
+# Get leaderboard
+leaderboard = requests.get('http://<trading-engine-host>:8080/api/v1/leaderboard')
+print(leaderboard.json())
 ```
 
 ### curl Examples
@@ -465,6 +545,9 @@ curl http://<trading-engine-host>:8080/api/v1/stats/all
 
 # Get market summary
 curl http://<trading-engine-host>:8080/api/v1/stats/summary
+
+# Get leaderboard
+curl http://<trading-engine-host>:8080/api/v1/leaderboard
 
 # Health check  
 curl http://<trading-engine-host>:8080/health

--- a/include/trading/core/matching_engine.hpp
+++ b/include/trading/core/matching_engine.hpp
@@ -43,6 +43,7 @@ class MatchingEngine {
     std::shared_ptr<User> getUser(const std::string& user_id);
     std::shared_ptr<User> getOrCreateUser(const std::string& user_id,
                                           double starting_cash = 10000.0);
+    const std::map<std::string, std::shared_ptr<User>>& getAllUsers() const;
 
     // Event handling
     void setTradeCallback(TradeCallback callback);

--- a/src/core/matching_engine.cpp
+++ b/src/core/matching_engine.cpp
@@ -220,6 +220,10 @@ std::shared_ptr<User> MatchingEngine::getOrCreateUser(const std::string& user_id
     return user;
 }
 
+const std::map<std::string, std::shared_ptr<User>>& MatchingEngine::getAllUsers() const {
+    return users_;
+}
+
 bool MatchingEngine::updateUserPortfolios(const Trade& trade, double fee) {
     // Get or create users (with default starting cash if new)
     auto buyer = getOrCreateUser(trade.buy_user_id);


### PR DESCRIPTION
This pull request adds a new leaderboard API endpoint to the trading engine, allowing clients to retrieve a live ranking of users by their net worth (cash plus portfolio value at current market prices). The changes include both backend implementation and documentation updates, as well as usage examples for the new endpoint.

**Leaderboard feature implementation:**

* Added a new HTTP GET endpoint `/api/v1/leaderboard` to the trading engine, which returns a JSON-formatted leaderboard of users ranked by net worth, including details such as cash balance, portfolio value, realized PnL, and position breakdowns. [[1]](diffhunk://#diff-84d8e10b0b1e85f8913c816477c3694f2f300ced604f063c9d5a41c2b55b5f77R210-R214) [[2]](diffhunk://#diff-84d8e10b0b1e85f8913c816477c3694f2f300ced604f063c9d5a41c2b55b5f77R538-R688)
* Introduced a new method `getAllUsers()` in the `MatchingEngine` class and implemented it to provide access to all users for leaderboard calculation. [[1]](diffhunk://#diff-61f266406770daf29c9e35eca9043682148542d631ba9e5ec4002d6d8f8a0436R46) [[2]](diffhunk://#diff-c67d3b939f17b771610234cd1881e4462442992703c72221f0c296a32e9c4e2aR223-R226)

**Documentation and usage examples:**

* Updated `README.md` to document the new `/api/v1/leaderboard` endpoint, including request/response format and explanation of response fields.
* Added Python and curl usage examples to the documentation for retrieving the leaderboard. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R513-R516) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R549-R551)

**Miscellaneous:**

* Included missing C++ headers (`<algorithm>`, `<limits>`) in `main.cpp` to support the leaderboard implementation.